### PR TITLE
Artefacts: added output schemas for SpecDataExtractor and DistributionGoSymbolExtractor

### DIFF
--- a/system/artefacts/schemas/golang-ipprefix-to-package-name.json
+++ b/system/artefacts/schemas/golang-ipprefix-to-package-name.json
@@ -1,0 +1,29 @@
+{
+        "schema": "http://json-schema.org/draft-04/schema#",
+        "title": "Golang ipprefix to package name",
+        "description": "Import path prefix to package name in distribution",
+        "type": "object",
+        "properties": {
+                "artefact": {
+                        "description": "Artefact name",
+                        "type": "string"
+                },
+                "product": {
+                        "description": "Product name",
+                        "type": "string"
+                },
+                "distribution": {
+                        "description": "Distribution name",
+                        "type" : "string"
+                },
+                "ipprefix": {
+                        "description": "Import path prefix",
+                        "type": "string"
+                },
+                "name": {
+                        "description": "Package name",
+                        "type": "string"
+                }
+        },
+        "required": ["artefact", "product", "distribution", "ipprefix", "name"]
+}

--- a/system/artefacts/schemas/golang-project-distribution-exported-api.json
+++ b/system/artefacts/schemas/golang-project-distribution-exported-api.json
@@ -167,7 +167,7 @@
 			"minItems": 1
 		}
 	},
-	"required": ["artefact", "project", "commit", "packages"],
+	"required": ["artefact", "project", "commit", "packages", "product", "distribution", "build", "rpm"],
 	"definitions": {
 		"identifier": {
 			"type": "object",

--- a/system/artefacts/schemas/golang-project-distribution-exported-api.json
+++ b/system/artefacts/schemas/golang-project-distribution-exported-api.json
@@ -1,0 +1,601 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Golang project distribution exported api artefact",
+	"description": "Definition of exported api of a golang project in a distribution",
+	"type": "object",
+	"properties": {
+		"artefact": {
+			"description": "Artefact name",
+			"type": "string"
+		},
+		"project": {
+			"description": "Project name",
+			"type": "string"
+		},
+		"commit": {
+			"description": "Project's commit",
+			"type": "string"
+		},
+		"product": {
+			"description": "Product name",
+			"type": "string"
+		},
+		"distribution": {
+                        "description": "Distribution name",
+                        "type": "string"
+                },
+		"build": {
+                        "description": "Build name",
+                        "type": "string"
+                },
+		"rpm": {
+                        "description": "RPM name",
+                        "type": "string"
+                },
+		"packages": {
+			"type": "array",
+			"description": "definition of exported API for defined packages",
+			"items": {
+				"type": "object",
+				"description": "list of packages with exported symbols",
+				"properties": {
+					"package": {
+						"type": "string",
+						"description": "Package name",
+						"minLength": 1
+					},
+					"datatypes": {
+						"description": "Definition of all data types for a given package",
+						"type": "array",
+						"items": {
+							"type": "object",
+							"description": "Data type definition",
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "Data type name",
+									"minLength": 1
+								},
+								"def": {
+									"oneOf": [
+										{ "$ref": "#/definitions/identifier" },
+										{ "$ref": "#/definitions/selector" },
+										{ "$ref": "#/definitions/channel" },
+										{ "$ref": "#/definitions/slice" },
+										{ "$ref": "#/definitions/array" },
+										{ "$ref": "#/definitions/map" },
+										{ "$ref": "#/definitions/pointer" },
+										{ "$ref": "#/definitions/ellipsis" },
+										{ "$ref": "#/definitions/function" },
+										{ "$ref": "#/definitions/method" },
+										{ "$ref": "#/definitions/interface" },
+										{ "$ref": "#/definitions/struct" }
+									]
+								}
+							},
+							"required": ["name", "def"]
+						}
+					},
+					"functions": {
+						"description": "Definition of all functions for a given package",
+						"type": "array",
+						"items": {
+							"type": "object",
+							"description": "Function type definition",
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "Function type name",
+									"minLength": 1
+								},
+								"def": {
+									"oneOf": [
+										{ "$ref": "#/definitions/function" },
+										{ "$ref": "#/definitions/method" }
+									]
+								}
+							},
+							"required": ["name", "def"]
+						}
+
+					},
+					"variables": {
+						"description": "Definition of all exported variables for a given package",
+						"type": "array",
+						"items": {
+							"type": "object",
+							"description": "Variable type definition",
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "Data type name",
+									"minLength": 1
+								},
+								"def": {
+									"oneOf": [
+										{ "$ref": "#/definitions/identifier" },
+										{ "$ref": "#/definitions/selector" },
+										{ "$ref": "#/definitions/channel" },
+										{ "$ref": "#/definitions/slice" },
+										{ "$ref": "#/definitions/array" },
+										{ "$ref": "#/definitions/map" },
+										{ "$ref": "#/definitions/pointer" },
+										{ "$ref": "#/definitions/function" },
+										{ "$ref": "#/definitions/method" },
+										{ "$ref": "#/definitions/interface" },
+										{ "$ref": "#/definitions/struct" }
+									]
+								}
+							},
+							"required": ["name"]
+						}
+					},
+					"constants": {
+						"description": "Definition of all exported constants for a given package",
+						"type": "array",
+						"items": {
+							"type": "object",
+							"description": "Variable type definition",
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "Data type name",
+									"minLength": 1
+								},
+								"def": {
+									"oneOf": [
+										{ "$ref": "#/definitions/identifier" },
+										{ "$ref": "#/definitions/selector" },
+										{ "$ref": "#/definitions/channel" },
+										{ "$ref": "#/definitions/slice" },
+										{ "$ref": "#/definitions/array" },
+										{ "$ref": "#/definitions/map" },
+										{ "$ref": "#/definitions/pointer" },
+										{ "$ref": "#/definitions/function" },
+										{ "$ref": "#/definitions/method" },
+										{ "$ref": "#/definitions/interface" },
+										{ "$ref": "#/definitions/struct" }
+									]
+								}
+							},
+							"required": ["name", "def"]
+						}
+					}
+				}
+			},
+			"uniqueItems": true,
+			"minItems": 1
+		}
+	},
+	"required": ["artefact", "project", "commit", "packages"],
+	"definitions": {
+		"identifier": {
+			"type": "object",
+			"description": "Identifier definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "Type identifier",
+					"oneOf": [
+						{"enum": ["identifier"]}
+					]
+				},
+				"def": {
+					"type": "string",
+					"description": "Primitive type or ID",
+					"minLength": 1
+				}
+			},
+			"required": ["type", "def"]
+		},
+		"selector": {
+			"type": "object",
+			"description": "Identifier definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "Type identifier",
+					"oneOf": [
+						{"enum": ["selector"]}
+					]
+				},
+				"prefix": {
+					"type": "object",
+					"description": "Prefix definition",
+					"oneOf": [
+						{ "$ref": "#/definitions/identifier" }
+					]
+				},
+				"item": {
+					"type": "string",
+					"description": "Item identifier",
+					"minLength": 1
+				}
+			},
+			"required": ["type", "prefix", "item"]
+		},
+		"channel": {
+			"type": "object",
+			"description": "Channel definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "Type identifier",
+					"oneOf": [
+						{"enum": ["channel"]}
+					]
+				},
+				"dir": {
+					"type": "string",
+					"description": "Direction specification",
+					"oneOf": [
+						{"enum": ["1", "2", "3"]}
+					]
+				},
+				"value": {
+					"type": "object",
+					"description": "Value definition",
+					"oneOf": [
+						{ "$ref": "#/definitions/identifier" },
+						{ "$ref": "#/definitions/selector" },
+						{ "$ref": "#/definitions/channel" },
+						{ "$ref": "#/definitions/slice" },
+						{ "$ref": "#/definitions/array" },
+						{ "$ref": "#/definitions/map" },
+						{ "$ref": "#/definitions/pointer" },
+						{ "$ref": "#/definitions/function" },
+						{ "$ref": "#/definitions/method" },
+						{ "$ref": "#/definitions/interface" },
+						{ "$ref": "#/definitions/struct" }
+					]
+				}
+			},
+			"required": ["type", "dir", "value"]
+		},
+		"slice": {
+			"type": "object",
+			"description": "Slice definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "Type identifier",
+					"oneOf": [
+						{"enum": ["slice"]}
+					]
+				},
+				"elmtype": {
+					"type": "object",
+					"description": "Element type definition",
+					"oneOf": [
+						{ "$ref": "#/definitions/identifier" },
+						{ "$ref": "#/definitions/selector" },
+						{ "$ref": "#/definitions/channel" },
+						{ "$ref": "#/definitions/slice" },
+						{ "$ref": "#/definitions/array" },
+						{ "$ref": "#/definitions/map" },
+						{ "$ref": "#/definitions/pointer" },
+						{ "$ref": "#/definitions/function" },
+						{ "$ref": "#/definitions/method" },
+						{ "$ref": "#/definitions/interface" },
+						{ "$ref": "#/definitions/struct" }
+					]
+				}
+			},
+			"required": ["type", "elmtype"]
+		},
+		"array": {
+			"type": "object",
+			"description": "Array definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "type identifier",
+					"oneOf": [
+						{"enum": ["array"]}
+					]
+				},
+				"elmtype": {
+					"type": "object",
+					"description": "element type definition",
+					"anyOf": [
+						{ "$ref": "#/definitions/identifier" },
+						{ "$ref": "#/definitions/selector" },
+						{ "$ref": "#/definitions/channel" },
+						{ "$ref": "#/definitions/slice" },
+						{ "$ref": "#/definitions/array" },
+						{ "$ref": "#/definitions/map" },
+						{ "$ref": "#/definitions/pointer" },
+						{ "$ref": "#/definitions/function" },
+						{ "$ref": "#/definitions/method" },
+						{ "$ref": "#/definitions/interface" },
+						{ "$ref": "#/definitions/struct" }
+					]
+				}
+			},
+			"required": ["type", "elmtype"]
+		},
+		"map": {
+			"type": "object",
+			"description": "Map definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "type identifier",
+					"oneOf": [
+						{"enum": ["map"]}
+					]
+				},
+				"keytype": {
+					"type": "object",
+					"description": "Key type definition",
+					"anyOf": [
+						{ "$ref": "#/definitions/identifier" },
+						{ "$ref": "#/definitions/selector" },
+						{ "$ref": "#/definitions/channel" },
+						{ "$ref": "#/definitions/slice" },
+						{ "$ref": "#/definitions/array" },
+						{ "$ref": "#/definitions/map" },
+						{ "$ref": "#/definitions/pointer" },
+						{ "$ref": "#/definitions/function" },
+						{ "$ref": "#/definitions/method" },
+						{ "$ref": "#/definitions/interface" },
+						{ "$ref": "#/definitions/struct" }
+					]
+				},
+				"valuetype": {
+					"type": "object",
+					"description": "Key type definition",
+					"anyOf": [
+						{ "$ref": "#/definitions/identifier" },
+						{ "$ref": "#/definitions/selector" },
+						{ "$ref": "#/definitions/channel" },
+						{ "$ref": "#/definitions/slice" },
+						{ "$ref": "#/definitions/array" },
+						{ "$ref": "#/definitions/map" },
+						{ "$ref": "#/definitions/pointer" },
+						{ "$ref": "#/definitions/function" },
+						{ "$ref": "#/definitions/method" },
+						{ "$ref": "#/definitions/interface" },
+						{ "$ref": "#/definitions/struct" }
+					]
+				}
+
+			},
+			"required": ["type", "keytype", "valuetype"]
+		},
+		"pointer": {
+			"type": "object",
+			"description": "Pointer definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "type identifier",
+					"oneOf": [
+						{"enum": ["pointer"]}
+					]
+				},
+				"def": {
+					"type": "object",
+					"description": "Pointed type definition",
+					"anyOf": [
+						{ "$ref": "#/definitions/identifier" },
+						{ "$ref": "#/definitions/selector" },
+						{ "$ref": "#/definitions/channel" },
+						{ "$ref": "#/definitions/slice" },
+						{ "$ref": "#/definitions/array" },
+						{ "$ref": "#/definitions/map" },
+						{ "$ref": "#/definitions/pointer" },
+						{ "$ref": "#/definitions/function" },
+						{ "$ref": "#/definitions/method" },
+						{ "$ref": "#/definitions/interface" },
+						{ "$ref": "#/definitions/struct" }
+					]
+				}
+			},
+			"required": ["type", "def"]
+		},
+		"ellipsis": {
+			"type": "object",
+			"description": "Pointer definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "type identifier",
+					"oneOf": [
+						{"enum": ["ellipsis"]}
+					]
+				},
+				"def": {
+					"type": "object",
+					"description": "Ellipses type definition",
+					"anyOf": [
+						{ "$ref": "#/definitions/identifier" },
+						{ "$ref": "#/definitions/selector" },
+						{ "$ref": "#/definitions/channel" },
+						{ "$ref": "#/definitions/slice" },
+						{ "$ref": "#/definitions/array" },
+						{ "$ref": "#/definitions/map" },
+						{ "$ref": "#/definitions/pointer" },
+						{ "$ref": "#/definitions/function" },
+						{ "$ref": "#/definitions/method" },
+						{ "$ref": "#/definitions/interface" },
+						{ "$ref": "#/definitions/struct" }
+					]
+				}
+			},
+			"required": ["type", "def"]
+		},
+		"function": {
+			"type": "object",
+			"description": "Function definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "Type identifier",
+					"oneOf": [
+						{"enum": ["function"]}
+					]
+				},
+				"params": {
+					"type": "array",
+					"description": "List of parameters",
+					"items": {
+						"type": "object",
+						"description": "Parameter type definition",
+						"anyOf": [
+							{ "$ref": "#/definitions/identifier" },
+							{ "$ref": "#/definitions/selector" },
+							{ "$ref": "#/definitions/channel" },
+							{ "$ref": "#/definitions/slice" },
+							{ "$ref": "#/definitions/array" },
+							{ "$ref": "#/definitions/map" },
+							{ "$ref": "#/definitions/pointer" },
+							{ "$ref": "#/definitions/ellipsis" },
+							{ "$ref": "#/definitions/function" },
+							{ "$ref": "#/definitions/method" },
+							{ "$ref": "#/definitions/interface" },
+							{ "$ref": "#/definitions/struct" }
+						]
+
+					}
+				},
+				"results": {
+					"type": "array",
+					"description": "List of results",
+					"items": {
+						"type": "object",
+						"description": "Results type definition",
+						"anyOf": [
+							{ "$ref": "#/definitions/identifier" },
+							{ "$ref": "#/definitions/selector" },
+							{ "$ref": "#/definitions/channel" },
+							{ "$ref": "#/definitions/slice" },
+							{ "$ref": "#/definitions/array" },
+							{ "$ref": "#/definitions/map" },
+							{ "$ref": "#/definitions/pointer" },
+							{ "$ref": "#/definitions/function" },
+							{ "$ref": "#/definitions/method" },
+							{ "$ref": "#/definitions/interface" },
+							{ "$ref": "#/definitions/struct" }
+						]
+
+					}
+				}
+
+			},
+			"required": ["type", "params", "results"]
+		},
+		"method": {
+			"type": "object",
+			"description": "Method definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "type identifier",
+					"oneOf": [
+						{"enum": ["method"]}
+					]
+				},
+				"receiver": {
+					"type": "object",
+					"description": "Receiver type definition",
+					"anyOf": [
+						{ "$ref": "#/definitions/identifier" },
+						{ "$ref": "#/definitions/selector" },
+						{ "$ref": "#/definitions/pointer" }
+					]
+				},
+				"def": {
+					"type": "object",
+					"description": "Function type definition",
+					"oneOf": [
+						{ "$ref": "#/definitions/function" }
+					]
+				}
+			},
+			"required": ["receiver", "def"]
+		},
+		"interface": {
+			"type": "object",
+			"description": "Interface definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "type identifier",
+					"oneOf": [
+						{"enum": ["interface"]}
+					]
+				},
+				"methods": {
+					"type": "array",
+					"description": "List of methods",
+					"items": {
+						"type": "object",
+						"description": "Method definition",
+						"properties": {
+							"name": {
+								"type": "string",
+								"description": "Method name",
+								"minLength": 1
+							},
+							"def": {
+								"type": "object",
+								"description": "Function type definition",
+								"oneOf": [
+									{ "$ref": "#/definitions/function" }
+								]	
+							}
+						},
+						"required": ["name", "def"]
+					},
+					"uniqueItems": true
+				}
+			},
+			"required": ["type", "methods"]
+		},
+		"struct": {
+			"type": "object",
+			"description": "Struct definition",
+			"properties": {
+				"type": {
+					"type": "string",
+					"description": "Type identifier"
+				},
+				"fields": {
+					"type": "array",
+					"description": "Definition of fields",
+					"items": {
+						"type": "object",
+						"description": "Field definition",
+						"properties": {
+							"name": {
+								"type": "string",
+								"description": "Field name. Anonymous if omited."
+							},
+							"def": {
+								"type": "object",
+								"description": "Type definition",
+								"anyOf": [
+									{ "$ref": "#/definitions/identifier" },
+									{ "$ref": "#/definitions/selector" },
+									{ "$ref": "#/definitions/channel" },
+									{ "$ref": "#/definitions/slice" },
+									{ "$ref": "#/definitions/array" },
+									{ "$ref": "#/definitions/map" },
+									{ "$ref": "#/definitions/pointer" },
+									{ "$ref": "#/definitions/function" },
+									{ "$ref": "#/definitions/method" },
+									{ "$ref": "#/definitions/interface" },
+									{ "$ref": "#/definitions/struct" }
+								]
+							}
+						},
+						"required": ["def"]
+					},
+					"uniqueItems": true
+				}
+			},
+			"required": ["type", "fields"]
+		}
+	}
+}

--- a/system/artefacts/schemas/golang-project-distribution-packages.json
+++ b/system/artefacts/schemas/golang-project-distribution-packages.json
@@ -131,5 +131,5 @@
 			"required": ["packages", "dependencies"]
 		}
 	},
-	"required": ["artefact", "project", "commit", "ipprefix", "data"]
+	"required": ["artefact", "project", "commit", "ipprefix", "data", "product", "distribution", "build", "rpm"]
 }

--- a/system/artefacts/schemas/golang-project-distribution-packages.json
+++ b/system/artefacts/schemas/golang-project-distribution-packages.json
@@ -1,0 +1,135 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Golang project distribution packages artefact",
+	"description": "Definition of packages of a golang project in a distribution",
+	"type": "object",
+	"properties": {
+		"artefact": {
+			"description": "Artefact name",
+			"type": "string"
+		},
+		"project": {
+			"description": "Project name",
+			"type": "string"
+		},
+		"commit": {
+			"description": "Project's commit",
+			"type": "string"
+		},
+		"ipprefix": {
+			"description": "Import path prefix",
+			"type": "string"
+		},
+		"product": {
+			"description": "Product name",
+			"type": "string"
+		},
+		"distribution": {
+                        "description": "Distribution name",
+                        "type": "string"
+		},
+                "build": {
+                        "description": "Build name",
+                        "type": "string"
+                },
+                "rpm": {
+                        "description": "RPM name",
+                        "type": "string"
+                },
+		"data": {
+			"description": "Data",
+			"type": "object",
+			"properties": {
+				"packages": {
+					"description": "List of defined packages with exported symbols",
+					"type": "array",
+					"items": {
+						"type": "string",
+						"description": "Package"
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				},
+				"dependencies": {
+					"description": "List of dependencies for each defined package",
+					"type": "array",
+					"items": {
+						"type": "object",
+						"description": "list of dependencies",
+						"properties": {
+							"package": {
+								"type": "string",
+								"description": "package name"
+							},
+							"dependencies": {
+								"type": "array",
+								"description": "dependencies",
+								"items": {
+									"type": "string",
+									"description": "dependency"
+								},
+								"uniqueItems": true
+							}
+						},
+						"required": ["package", "dependencies"]
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				},
+				"tests": {
+					"description": "List of tests",
+					"type": "array",
+					"items": {
+						"type": "object",
+						"description": "test",
+						"properties": {
+							"test": {
+								"type": "string",
+								"description": "test name",
+								"minLength": 1
+							},
+							"dependencies": {
+								"type": "array",
+								"description": "dependencies",
+								"items": {
+									"type": "string",
+									"description": "dependency"
+								},
+								"uniqueItems": true
+							}
+						}
+					},
+					"uniqueItems": true
+				},
+				"main": {
+					"description": "List of files with 'package main' clause",
+					"type": "array",
+					"items": {
+						"type": "object",
+						"description": "Buildable main go file",
+						"object": {
+							"filename": {
+								"type": "string",
+								"description": "main filename",
+								"minLength": 1
+							},
+							"dependencies": {
+								"type": "array",
+								"description": "dependencies",
+								"items": {
+									"type": "string",
+									"description": "dependency"
+								},
+								"uniqueItems": true
+							}
+						},
+						"required": ["filename"]
+					},
+					"uniqueItems": true
+				}
+			},
+			"required": ["packages", "dependencies"]
+		}
+	},
+	"required": ["artefact", "project", "commit", "ipprefix", "data"]
+}

--- a/system/artefacts/schemas/golang-project-info-fedora.json
+++ b/system/artefacts/schemas/golang-project-info-fedora.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Golang project distribution information",
+	"description": "General distribution related information about a project",
+	"type": "object",
+	"properties": {
+		"artefact": {
+			"description": "Artefact name",
+			"type": "string"
+		},
+		"distribution": {
+			"description": "Distribution",
+			"type": "string"
+		},
+		"project": {
+			"description": "Project name",
+			"type": "string"
+		},
+		"commit": {
+			"description": "Project's commit",
+			"type": "string"
+		},
+		"last-updated": {
+			"description": "Last date updated",
+			"type": "string"
+		}
+	},
+	"required": ["artefact", "distribution", "project", "commit", "last-updated"]
+}

--- a/system/artefacts/schemas/golang-project-to-package-name.json
+++ b/system/artefacts/schemas/golang-project-to-package-name.json
@@ -1,0 +1,29 @@
+{
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "Golang project to package name",
+        "description": "Package name of project in distribution",
+        "type": "object",
+        "properties": {
+                "artefact": {
+                        "description": "Artefact name",
+                        "type": "string"
+                },
+                "product": {
+                        "description": "Product name",
+                        "type": "string"
+                },
+                "distribution": {
+                        "description": "Distribution name",
+                        "type" : "string"
+                },
+                "project": {
+                        "description": "Project name",
+                        "type": "string"
+                },
+                "name": {
+                        "description": "Package name",
+                        "type": "string"
+                }
+        },
+        "required": ["artefact", "product", "distribution", "project", "name"]
+}


### PR DESCRIPTION
Files copied from gofed/docs:
system/artefacts/schemas/golang-ipprefix-to-package-name.json
system/artefacts/schemas/golang-project-info-fedora.json
system/artefacts/schemas/golang-project-to-package-name.json

Extensions of existing schemas:
system/artefacts/schemas/golang-project-distribution-exported-api.json
system/artefacts/schemas/golang-project-distribution-packages.json